### PR TITLE
task_6

### DIFF
--- a/project/cfg.py
+++ b/project/cfg.py
@@ -1,0 +1,33 @@
+from os import PathLike
+from typing import Union
+
+from pyformlang.cfg import CFG
+from pyformlang.cfg import Variable
+
+
+def cfg_to_wcnf(cfg: Union[CFG, str], starting: str = "S") -> CFG:
+    if isinstance(cfg, str):
+        cfg = CFG.from_text(cfg, Variable(starting))
+
+    # По записям в моих конспектах единственное отличие в преобразовании CFG к WCNF в сравнении с
+    # преобразованием CFG к CNF заключается в отсутствии того шага, на котором устраняются эпсилон-продукции.
+
+    # Заимствуем код из pyformlang метода CFG.to_normal_form()
+    new_cfg = (
+        cfg.remove_useless_symbols()
+        .eliminate_unit_productions()
+        .remove_useless_symbols()
+    )
+
+    new_productions = new_cfg._get_productions_with_only_single_terminals()
+    new_productions = new_cfg._decompose_productions(new_productions)
+
+    cfg_in_wcnf = CFG(start_symbol=cfg._start_symbol, productions=set(new_productions))
+
+    return cfg_in_wcnf
+
+
+def read_cfg(path: PathLike, starting: str = "S") -> CFG:
+    with open(path, "r") as f:
+        data = f.read()
+    return CFG.from_text(data, Variable(starting))

--- a/tests/task_6/test_cfg.json
+++ b/tests/task_6/test_cfg.json
@@ -1,0 +1,59 @@
+{
+  "test_cfg": [
+    {
+      "cfg": "",
+      "starting": null,
+      "wcnf": ""
+    },
+    {
+      "cfg": "S1 -> a",
+      "starting": "S1",
+      "wcnf": "S1 -> a"
+    },
+    {
+      "cfg": "S1 -> a",
+      "starting": "S",
+      "wcnf": ""
+    },
+    {
+      "cfg": "S -> A B\nA -> a\nB -> b",
+      "starting": "S",
+      "wcnf": "S -> A B\nA -> a\nB -> b"
+    },
+    {
+      "cfg": "S -> a b",
+      "starting": null,
+      "wcnf": "S -> \"VAR:a#CNF#\" \"VAR:b#CNF#\" \n \"VAR:a#CNF#\" -> a \n \"VAR:b#CNF#\" -> b"
+    },
+    {
+      "cfg": "S -> A S | epsilon\nA -> a",
+      "starting": null,
+      "wcnf": "S -> A S | epsilon\nA -> a"
+    },
+    {
+      "cfg": "S -> A \n A -> a",
+      "starting": null,
+      "wcnf": "S -> a"
+    },
+    {
+      "cfg": "S -> epsilon",
+      "starting": null,
+      "wcnf": "S -> epsilon"
+    },
+    {
+      "cfg": "S -> A B C D E\nA -> a\nB -> b\nC -> c\nD -> d\nE -> e",
+      "starting": null,
+      "wcnf": "S -> A C#CNF#1\nC#CNF#1 -> B C#CNF#2\nC#CNF#2 -> C C#CNF#3\nC#CNF#3 -> D E\nA -> a\nB -> b\nC -> c\nD -> d\nE -> e"
+    },
+    {
+      "cfg": "S -> a b c epsilon",
+      "starting": null,
+      "wcnf": "S -> \"VAR:a#CNF#\" C#CNF#1\nC#CNF#1 -> \"VAR:b#CNF#\" \"VAR:c#CNF#\"\na#CNF# -> a\nb#CNF# -> b\nc#CNF# -> c\n"
+    },
+    {
+      "cfg": "S -> A\nA -> B\nB -> b",
+      "starting": null,
+      "wcnf": "S -> b"
+    }
+  ]
+}

--- a/tests/task_6/test_cfg.py
+++ b/tests/task_6/test_cfg.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import pytest
+from tests.utils import read_data_from_json
+from project.cfg import cfg_to_wcnf, read_cfg
+from pyformlang.cfg import CFG
+
+
+def eq(cfg1: CFG, cfg2: CFG):
+    return cfg1.productions.__eq__(cfg2.productions) and cfg1.start_symbol.__eq__(
+        cfg2.start_symbol
+    )
+
+
+@pytest.mark.parametrize(
+    "cfg, starting, expected_wcnf",
+    read_data_from_json(
+        "test_cfg",
+        lambda data: (
+            data["cfg"],
+            data["starting"],
+            CFG.from_text(data["wcnf"])
+            if data["starting"] is None
+            else CFG.from_text(data["wcnf"], data["starting"]),
+        ),
+    ),
+)
+def test_cfg_to_wcnf(cfg: str, starting: str, expected_wcnf: CFG):
+    if starting is None:
+        actual_wcnf = cfg_to_wcnf(cfg)
+    else:
+        actual_wcnf = cfg_to_wcnf(cfg, starting)
+
+    assert eq(actual_wcnf, expected_wcnf)
+
+
+@pytest.fixture
+def path(request, tmp_path: Path) -> Path:
+    cfg = request.param
+
+    path = tmp_path / "cfg.txt"
+    with open(path, "w") as f:
+        f.write(cfg)
+    return path
+
+
+@pytest.mark.parametrize(
+    "path, starting, expected_cfg",
+    read_data_from_json(
+        "test_cfg",
+        lambda data: (
+            data["cfg"],
+            data["starting"],
+            CFG.from_text(data["cfg"])
+            if data["starting"] is None
+            else CFG.from_text(data["cfg"], data["starting"]),
+        ),
+    ),
+    indirect=["path"],
+)
+def test_read_cfg(path, starting: str, expected_cfg: CFG):
+    actual = read_cfg(path, starting) if starting is not None else read_cfg(path)
+
+    assert eq(actual, expected_cfg)


### PR DESCRIPTION
# Задача 6. Преобразование грамматики в ОНФХ

- [x] Используя [возможности pyformlang для работы с контекстно-свободными грамматиками](https://pyformlang.readthedocs.io/en/latest/modules/context_free_grammar.html) реализовать **функцию** преобразования контекстно-свободной грамматики в ослабленную нормальную форму Хомского (ОНФХ), но не классическую нормальную форму Хомского (НФХ). НФХ является частным случаем ОНФХ, а значит можно утверждать, что грамматика, находящаяся в НФХ находится и в ОНФХ. Но в данной задаче нас интересует максимально слабая форма, то есть ОНФХ, но не НФХ.
- [x] Предусмотреть возможность чтения грамматики из файла. Формат файла определяется возможностями pyformalng. Например, можно использовать [эту функцию](https://pyformlang.readthedocs.io/en/latest/modules/context_free_grammar.html#pyformlang.cfg.CFG.from_text).
- [x] Добавить необходимые тесты.